### PR TITLE
[#33] 유저 조회 API

### DIFF
--- a/src/main/kotlin/com/example/daitssuapi/common/enums/ErrorCode.kt
+++ b/src/main/kotlin/com/example/daitssuapi/common/enums/ErrorCode.kt
@@ -10,6 +10,7 @@ enum class ErrorCode(val code: Int, val message: String) {
     DEPARTMENT_NOT_FOUND(MAIN_NUMBERING + 2, "학과를 찾을 수 없습니다"),
     ARTICLE_NOT_FOUND(MAIN_NUMBERING + 3, "게시글을 찾을 수 없습니다."),
     NICKNAME_REQUIRED(MAIN_NUMBERING + 4, "닉네임이 필요한 작업입니다."),
+    USER_NICKNAME_MISSING(MAIN_NUMBERING + 5, "유저의 닉네임이 없습니다"),
 
     COURSE_NOT_FOUND(COURSE_NUMBERING + 1, "과목을 찾을 수 없습니다."),
     USER_COURSE_RELATION_NOT_FOUND(COURSE_NUMBERING + 2, "유저가 수강중인 강의를 찾을 수 없습니다."),

--- a/src/main/kotlin/com/example/daitssuapi/domain/course/service/CourseService.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/course/service/CourseService.kt
@@ -161,18 +161,6 @@ class CourseService(
         return CourseResponse(name = course.name, term = course.term)
     }
 
-//    fun getUserCourses(userId: Long): List<UserCourseResponse> =
-//        userCourseRelationRepository.findByUserIdOrderByCreatedAtDesc(userId = userId).filter {
-//            RegisterStatus.ACTIVE == it.registerStatus
-//        }.map {
-//            UserCourseResponse(
-//                courseId = it.course.id,
-//                name = it.course.name,
-//                term = it.course.term,
-//                updatedAt = it.course.updatedAt
-//            )
-//        }
-
     fun getUserCourses(userId: Long): List<UserCourseResponse> =
         userCourseRelationRepository.findByUserIdOrderByCreatedAtDesc(userId = userId).filter {
             RegisterStatus.ACTIVE == it.registerStatus

--- a/src/main/kotlin/com/example/daitssuapi/domain/main/controller/UserController.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/main/controller/UserController.kt
@@ -1,0 +1,37 @@
+package com.example.daitssuapi.domain.main.controller
+
+import com.example.daitssuapi.common.dto.Response
+import com.example.daitssuapi.domain.main.dto.response.UserResponse
+import com.example.daitssuapi.domain.main.service.UserService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/user")
+@Tag(name = "user", description = "유저 API")
+class UserController(
+    private val userService: UserService
+) {
+    @Operation(
+        summary = "유저 조회",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "OK"
+            ),
+            ApiResponse(
+                responseCode = "404",
+                description = "유저 없음"
+            )
+        ]
+    )
+    @GetMapping("/{userId}")
+    fun getUser(
+        @PathVariable userId: Long
+    ): Response<UserResponse> = Response(data = userService.getUser(userId = userId))
+}

--- a/src/main/kotlin/com/example/daitssuapi/domain/main/dto/response/UserResponse.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/main/dto/response/UserResponse.kt
@@ -1,0 +1,9 @@
+package com.example.daitssuapi.domain.main.dto.response
+
+data class UserResponse(
+    val studentId: Int,
+    val name: String,
+    val nickname: String,
+    val departmentName: String,
+    val term: Int
+)

--- a/src/main/kotlin/com/example/daitssuapi/domain/main/service/UserService.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/main/service/UserService.kt
@@ -1,0 +1,27 @@
+package com.example.daitssuapi.domain.main.service
+
+import com.example.daitssuapi.common.enums.ErrorCode
+import com.example.daitssuapi.common.exception.DefaultException
+import com.example.daitssuapi.domain.main.dto.response.UserResponse
+import com.example.daitssuapi.domain.main.model.repository.UserRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.http.HttpStatus
+import org.springframework.stereotype.Service
+
+@Service
+class UserService(
+    private val userRepository: UserRepository
+) {
+    fun getUser(userId: Long): UserResponse {
+        val user = (userRepository.findByIdOrNull(userId)
+            ?: throw DefaultException(errorCode = ErrorCode.USER_NOT_FOUND, httpStatus = HttpStatus.NOT_FOUND))
+
+        return UserResponse(
+            studentId = user.studentId,
+            name = user.name,
+            nickname = user.nickname ?: throw DefaultException(errorCode = ErrorCode.USER_NICKNAME_MISSING),
+            departmentName = user.department.name,
+            term = user.term
+        )
+    }
+}

--- a/src/test/kotlin/com/example/daitssuapi/domain/course/controller/CourseControllerTest.kt
+++ b/src/test/kotlin/com/example/daitssuapi/domain/course/controller/CourseControllerTest.kt
@@ -1,4 +1,4 @@
-package com.example.daitssuapi.domain.main.controller
+package com.example.daitssuapi.domain.course.controller
 
 import com.example.daitssuapi.domain.course.model.repository.UserCourseRelationRepository
 import com.example.daitssuapi.utils.ControllerTest

--- a/src/test/kotlin/com/example/daitssuapi/domain/course/service/CourseServiceTest.kt
+++ b/src/test/kotlin/com/example/daitssuapi/domain/course/service/CourseServiceTest.kt
@@ -1,8 +1,7 @@
-package com.example.daitssuapi.domain.main.service
+package com.example.daitssuapi.domain.course.service
 
 import com.example.daitssuapi.common.enums.RegisterStatus
 import com.example.daitssuapi.domain.course.model.repository.UserCourseRelationRepository
-import com.example.daitssuapi.domain.course.service.CourseService
 import com.example.daitssuapi.utils.IntegrationTest
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Assertions.*

--- a/src/test/kotlin/com/example/daitssuapi/domain/course/service/CourseServiceTest.kt
+++ b/src/test/kotlin/com/example/daitssuapi/domain/course/service/CourseServiceTest.kt
@@ -2,6 +2,7 @@ package com.example.daitssuapi.domain.course.service
 
 import com.example.daitssuapi.common.enums.RegisterStatus
 import com.example.daitssuapi.domain.course.model.repository.UserCourseRelationRepository
+import com.example.daitssuapi.domain.main.model.repository.UserRepository
 import com.example.daitssuapi.utils.IntegrationTest
 import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Assertions.*
@@ -11,7 +12,7 @@ import org.junit.jupiter.api.Test
 @IntegrationTest
 class CourseServiceTest(
     private val courseService: CourseService,
-    private val userRepository: UserCourseRelationRepository,
+    private val userRepository: UserRepository,
     private val userCourseRelationRepository: UserCourseRelationRepository
 ) {
     @Test

--- a/src/test/kotlin/com/example/daitssuapi/domain/main/controller/UserControllerTest.kt
+++ b/src/test/kotlin/com/example/daitssuapi/domain/main/controller/UserControllerTest.kt
@@ -1,0 +1,45 @@
+package com.example.daitssuapi.domain.main.controller
+
+import com.example.daitssuapi.domain.main.model.repository.UserRepository
+import com.example.daitssuapi.utils.ControllerTest
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+
+@ControllerTest
+class UserControllerTest(
+    private val userRepository: UserRepository
+) {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
+    private val url = "/user"
+
+    @Test
+    @DisplayName("성공_올바른 userId를 이용하여 유저 조회 시_유저가 조회된다")
+    fun success_get_course_with_user_id() {
+        userRepository.findAll().forEach { user ->
+            val response = mockMvc.perform(MockMvcRequestBuilders.get("$url/${user.id}"))
+                .andExpect(MockMvcResultMatchers.status().isOk)
+                .andReturn().response
+            Assertions.assertThat(jacksonObjectMapper().readTree(response.contentAsString)["data"].isEmpty).isFalse()
+        }
+    }
+
+    @Test
+    @DisplayName("실패_잘못된 userId를 이용하여 유저 조회 시_404를 받는다")
+    fun success_get_empty_course_with_wrong_user_id() {
+        val wrongUserId = 0
+
+        val response = mockMvc.perform(MockMvcRequestBuilders.get("$url/$wrongUserId"))
+            .andExpect(MockMvcResultMatchers.status().isNotFound)
+            .andReturn().response
+        Assertions.assertThat(jacksonObjectMapper().readTree(response.contentAsString)["data"].isEmpty).isTrue
+    }
+}

--- a/src/test/kotlin/com/example/daitssuapi/domain/main/service/UserServiceTest.kt
+++ b/src/test/kotlin/com/example/daitssuapi/domain/main/service/UserServiceTest.kt
@@ -1,0 +1,40 @@
+package com.example.daitssuapi.domain.main.service
+
+import com.example.daitssuapi.common.exception.DefaultException
+import com.example.daitssuapi.domain.main.model.repository.UserRepository
+import com.example.daitssuapi.utils.IntegrationTest
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@IntegrationTest
+class UserServiceTest(
+    private val userRepository: UserRepository,
+    private val userService: UserService
+) {
+    @Test
+    @DisplayName("성공_올바른 userId를 이용하여 유저 조회 시_유저가 조회된다")
+    fun success_get_course_with_user_id() {
+        userRepository.findAll().forEach {
+            val findUser = userService.getUser(userId = it.id)
+
+            assertAll(
+                { assertThat(findUser.studentId).isEqualTo(it.id) },
+                { assertThat(findUser.name).isEqualTo(it.name) },
+                { assertThat(findUser.nickname).isEqualTo(it.nickname) },
+                { assertThat(findUser.departmentName).isEqualTo(it.department.name) },
+                { assertThat(findUser.term).isEqualTo(it.term) }
+            )
+        }
+    }
+
+    @Test
+    @DisplayName("실패_잘못된 userId를 이용하여 유저 조회 시_404를 받는다")
+    fun success_get_empty_course_with_wrong_user_id() {
+        val wrongUserId = 0L
+
+        assertThrows<DefaultException> { userService.getUser(userId = wrongUserId) }
+    }
+}


### PR DESCRIPTION
## Issue

- Resolves #33 

## Description

- 유저 조회 기능 추가
  - `userId`를 이용하여 조회
  - 유저 조회 불가 시 Http Status 404 `Not Found`

## Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  적절한 라벨 설정
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x]  `main` 브랜치의 최신 상태를 반영하고 있는지 확인
