### PR TITLE
[#22] 댓글 작성 및 조회

### DIFF
--- a/src/main/kotlin/com/example/daitssuapi/common/Constants.kt
+++ b/src/main/kotlin/com/example/daitssuapi/common/Constants.kt
@@ -1,0 +1,3 @@
+package com.example.daitssuapi.common
+
+const val DEFAULT_ENCODING = "UTF-8"

--- a/src/main/kotlin/com/example/daitssuapi/common/audit/BaseEntity.kt
+++ b/src/main/kotlin/com/example/daitssuapi/common/audit/BaseEntity.kt
@@ -10,7 +10,7 @@ import java.time.LocalDateTime
 @EntityListeners(AuditingEntityListener::class)
 abstract class BaseEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.AUTO)
     val id: Long = 0L
 
     @CreatedDate

--- a/src/main/kotlin/com/example/daitssuapi/common/enums/ErrorCode.kt
+++ b/src/main/kotlin/com/example/daitssuapi/common/enums/ErrorCode.kt
@@ -11,6 +11,9 @@ enum class ErrorCode(val code: Int, val message: String) {
     ARTICLE_NOT_FOUND(MAIN_NUMBERING + 3, "게시글을 찾을 수 없습니다."),
     NICKNAME_REQUIRED(MAIN_NUMBERING + 4, "닉네임이 필요한 작업입니다."),
     USER_NICKNAME_MISSING(MAIN_NUMBERING + 5, "유저의 닉네임이 없습니다"),
+    COMMENT_NOT_FOUND(MAIN_NUMBERING + 6, "원 댓글이 없습니다"),
+    COMMENT_TOO_LONG(MAIN_NUMBERING + 7, "댓글이 너무 깁니다"),
+    DIFFERENT_ARTICLE(MAIN_NUMBERING + 8, "다른 게시글에 달린 댓글의 대댓글입니다"),
 
     NOTICE_NOT_FOUND(NOTICE_NUMBERING + 1, "공지사항 내용을 찾을 수 없습니다"),
     FUNSYSTEM_NOT_FOUND(NOTICE_NUMBERING + 2, "펀시스템 내용을 찾을 수 없습니다"),
@@ -24,5 +27,5 @@ enum class ErrorCode(val code: Int, val message: String) {
     BAD_REQUEST(SERVER_NUMBERING + 1, "잘못된 요청입니다."),
     INVALID_FORMAT(SERVER_NUMBERING + 2, "잘못된 형식입니다."),
     INVALID_DATE_FORMAT(SERVER_NUMBERING + 3, "잘못된 날짜 형식입니다. yyyy-MM-dd HH:mm:ss 형식으로 요청바랍니다."),
-    INVALID_GET_DATE_FORMAT(SERVER_NUMBERING + 4, "잘못된 날짜 형식입니다. yyyy-MM 형식으로 요청바랍니다.")
+    INVALID_GET_DATE_FORMAT(SERVER_NUMBERING + 4, "잘못된 날짜 형식입니다. yyyy-MM 형식으로 요청바랍니다."),
 }

--- a/src/main/kotlin/com/example/daitssuapi/domain/main/controller/ArticleController.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/main/controller/ArticleController.kt
@@ -1,8 +1,10 @@
 package com.example.daitssuapi.domain.main.controller
 
 import com.example.daitssuapi.common.dto.Response
-import com.example.daitssuapi.domain.main.dto.response.ArticleResponse
 import com.example.daitssuapi.domain.main.dto.request.ArticleWriteRequest
+import com.example.daitssuapi.domain.main.dto.request.CommentWriteRequest
+import com.example.daitssuapi.domain.main.dto.response.ArticleResponse
+import com.example.daitssuapi.domain.main.dto.response.CommentResponse
 import com.example.daitssuapi.domain.main.service.ArticleService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -46,4 +48,33 @@ class ArticleController(
         @RequestBody articleWriteRequest: ArticleWriteRequest
     ): Response<ArticleResponse>
         = Response(data = articleService.writeArticle(articleWriteRequest))
+
+    @Operation(
+        summary = "댓글 작성",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "OK"
+            )
+        ]
+    )
+    @PostMapping("/{articleId}/comments")
+    fun writeComment(
+        @PathVariable articleId: Long,
+        @RequestBody commentWriteRequest: CommentWriteRequest
+    ): Response<CommentResponse> = Response(data = articleService.writeComment(articleId = articleId, request = commentWriteRequest))
+
+    @Operation(
+        summary = "댓글 조회",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "OK"
+            )
+        ]
+    )
+    @GetMapping("/{articleId}/comments")
+    fun getComments(
+        @PathVariable articleId: Long
+    ): Response<List<CommentResponse>> = Response(data = articleService.getComments(articleId = articleId))
 }

--- a/src/main/kotlin/com/example/daitssuapi/domain/main/dto/request/CommentWriteRequest.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/main/dto/request/CommentWriteRequest.kt
@@ -1,0 +1,7 @@
+package com.example.daitssuapi.domain.main.dto.request
+
+data class CommentWriteRequest(
+    val userId: Long,
+    val content: String,
+    val originalCommentId: Long? = null
+)

--- a/src/main/kotlin/com/example/daitssuapi/domain/main/model/entity/Comment.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/main/model/entity/Comment.kt
@@ -1,0 +1,20 @@
+package com.example.daitssuapi.domain.main.model.entity
+
+import com.example.daitssuapi.common.audit.BaseEntity
+import jakarta.persistence.*
+
+@Entity
+@Table(schema = "main")
+class Comment(
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    var writer: User,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "article_id")
+    var article: Article,
+
+    val content: String,
+
+    val originalId: Long? = null
+) : BaseEntity()

--- a/src/main/kotlin/com/example/daitssuapi/domain/main/model/repository/CommentRepository.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/main/model/repository/CommentRepository.kt
@@ -1,0 +1,8 @@
+package com.example.daitssuapi.domain.main.model.repository
+
+import com.example.daitssuapi.domain.main.model.entity.Comment
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface CommentRepository : JpaRepository<Comment, Long> {
+    fun findByArticleId(articleId: Long): List<Comment>
+}

--- a/src/main/kotlin/com/example/daitssuapi/domain/main/service/ArticleService.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/main/service/ArticleService.kt
@@ -1,20 +1,27 @@
 package com.example.daitssuapi.domain.main.service
 
+import com.example.daitssuapi.common.DEFAULT_ENCODING
 import com.example.daitssuapi.common.enums.ErrorCode
 import com.example.daitssuapi.common.exception.DefaultException
 import com.example.daitssuapi.domain.main.dto.request.ArticleWriteRequest
+import com.example.daitssuapi.domain.main.dto.request.CommentWriteRequest
 import com.example.daitssuapi.domain.main.dto.response.ArticleResponse
+import com.example.daitssuapi.domain.main.dto.response.CommentResponse
 import com.example.daitssuapi.domain.main.model.entity.Article
-import com.example.daitssuapi.domain.main.model.repository.ArticleRepository
+import com.example.daitssuapi.domain.main.model.entity.Comment
 import com.example.daitssuapi.domain.main.model.entity.User
+import com.example.daitssuapi.domain.main.model.repository.ArticleRepository
+import com.example.daitssuapi.domain.main.model.repository.CommentRepository
 import com.example.daitssuapi.domain.main.model.repository.UserRepository
 import jakarta.transaction.Transactional
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
+import java.nio.charset.Charset
 
 @Service
 class ArticleService(
     private val articleRepository: ArticleRepository,
+    private val commentRepository: CommentRepository,
     private val userRepository: UserRepository
 ) {
     fun getArticle(id: Long): ArticleResponse {
@@ -57,5 +64,62 @@ class ArticleService(
             writerNickName = user.nickname!!,
             updatedAt = savedArticle.updatedAt
         )
+    }
+
+    @Transactional
+    fun writeComment(articleId: Long, request: CommentWriteRequest): CommentResponse {
+        val user = userRepository.findByIdOrNull(request.userId)
+            ?: throw DefaultException(errorCode = ErrorCode.USER_NOT_FOUND)
+        val article = articleRepository.findByIdOrNull(articleId)
+            ?: throw DefaultException(errorCode = ErrorCode.ARTICLE_NOT_FOUND)
+
+        validateComment(article = article, content = request.content, originalCommentId = request.originalCommentId)
+
+        val comment = commentRepository.save(Comment(
+            writer = user,
+            article = article,
+            content = request.content,
+            originalId = request.originalCommentId
+        ))
+
+        return CommentResponse(
+            commentId = comment.id,
+            userId = comment.writer.id,
+            content = comment.content,
+            originalCommentId = comment.originalId,
+            createdAt = comment.createdAt,
+            updatedAt = comment.updatedAt
+        )
+    }
+
+    private fun validateComment(article: Article, content: String, originalCommentId: Long?) {
+        if (512 < content.toByteArray(Charset.forName(DEFAULT_ENCODING)).size) {
+            throw DefaultException(errorCode = ErrorCode.COMMENT_TOO_LONG)
+        }
+
+        originalCommentId?.apply {
+            val originalComment = commentRepository.findByIdOrNull(this)
+                ?: throw DefaultException(errorCode = ErrorCode.COMMENT_NOT_FOUND)
+
+            if (originalComment.article != article) {
+                throw DefaultException(errorCode = ErrorCode.DIFFERENT_ARTICLE)
+            }
+        }
+    }
+
+    fun getComments(articleId: Long): List<CommentResponse> {
+        articleRepository.findByIdOrNull(articleId)
+            ?: throw DefaultException(errorCode = ErrorCode.ARTICLE_NOT_FOUND)
+
+        return commentRepository.findByArticleId(articleId = articleId).map {
+            CommentResponse(
+                commentId = it.id,
+                userId = it.writer.id,
+                content = it.content,
+                originalCommentId = it.originalId,
+                createdAt = it.createdAt,
+                updatedAt = it.updatedAt
+            )
+        }
     }
 }

--- a/src/test/kotlin/com/example/daitssuapi/domain/main/controller/ArticleControllerTest.kt
+++ b/src/test/kotlin/com/example/daitssuapi/domain/main/controller/ArticleControllerTest.kt
@@ -2,9 +2,10 @@ package com.example.daitssuapi.domain.main.controller
 
 import com.example.daitssuapi.common.enums.ErrorCode
 import com.example.daitssuapi.domain.main.dto.request.ArticleWriteRequest
+import com.example.daitssuapi.domain.main.dto.request.CommentWriteRequest
 import com.example.daitssuapi.domain.main.enums.Topic
-import com.example.daitssuapi.domain.main.model.entity.Article
 import com.example.daitssuapi.domain.main.model.repository.ArticleRepository
+import com.example.daitssuapi.domain.main.model.repository.CommentRepository
 import com.example.daitssuapi.domain.main.model.repository.UserRepository
 import com.example.daitssuapi.utils.ControllerTest
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -21,6 +22,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 @ControllerTest
 class ArticleControllerTest(
     private val articleRepository: ArticleRepository,
+    private val commentRepository: CommentRepository,
     private val userRepository: UserRepository
 ) {
     @Autowired
@@ -31,24 +33,18 @@ class ArticleControllerTest(
     fun article_get_controller_test() {
         // given
         val baseUri = "/community/article"
-        val user = userRepository.findAll().filter { null != it.nickname }[0]
-        val savedArticle = articleRepository.save(Article(
-            topic = Topic.CHAT,
-            title = "테스트 제목",
-            content = "테스트 내용",
-            writer = user
-        ))
+        val article = articleRepository.findAll()[0]
 
         // when & then
         mockMvc.perform(
-            get("$baseUri/${savedArticle.id}")
+            get("$baseUri/${article.id}")
                 .header(HttpHeaders.AUTHORIZATION, "Bearer test")
         ).andExpect(status().isOk)
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("$.data.title").value(savedArticle.title))
-            .andExpect(jsonPath("$.data.content").value(savedArticle.content))
-            .andExpect(jsonPath("$.data.writerNickName").value(user.nickname))
-            .andExpect(jsonPath("$.data.topic").value(savedArticle.topic.value))
+            .andExpect(jsonPath("$.data.title").value(article.title))
+            .andExpect(jsonPath("$.data.content").value(article.content))
+            .andExpect(jsonPath("$.data.writerNickName").value(article.writer.nickname))
+            .andExpect(jsonPath("$.data.topic").value(article.topic.value))
     }
 
     @Test
@@ -102,5 +98,158 @@ class ArticleControllerTest(
                 .contentType(MediaType.APPLICATION_JSON)
         ).andExpect(jsonPath("$.code").value(ErrorCode.NICKNAME_REQUIRED.code))
             .andExpect(jsonPath("$.message").value(ErrorCode.NICKNAME_REQUIRED.message))
+    }
+
+    @Test
+    @DisplayName("성공_올바른 정보를 넘겨줄 때_댓글이 작성된다")
+    fun writeComment() {
+        val article = articleRepository.findAll()[0]
+        val user = userRepository.findAll()[0]
+        val url = "/community/article/${article.id}/comments"
+        val articleWriteRequest = CommentWriteRequest(
+            content = "댓글 추가",
+            userId = user.id,
+            originalCommentId = null
+        )
+        val request = jacksonObjectMapper().writeValueAsString(articleWriteRequest)
+
+        mockMvc.perform(
+            post(url)
+                .content(request)
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isOk)
+    }
+
+    @Test
+    @DisplayName("실패_게시글이 없을 때_댓글 작성에 실패한다")
+    fun writeCommentFailNoArticle() {
+        val user = userRepository.findAll()[0]
+        val url = "/community/article/0/comments"
+        val articleWriteRequest = CommentWriteRequest(
+            content = "댓글 추가",
+            userId = user.id,
+            originalCommentId = null
+        )
+        val request = jacksonObjectMapper().writeValueAsString(articleWriteRequest)
+
+        mockMvc.perform(
+            post(url)
+                .content(request)
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.code").value(ErrorCode.ARTICLE_NOT_FOUND.code))
+    }
+
+    @Test
+    @DisplayName("실패_유저가 없을 때_댓글 작성에 실패한다")
+    fun writeCommentFailNoUser() {
+        val article = articleRepository.findAll()[0]
+        val url = "/community/article/${article.id}/comments"
+        val articleWriteRequest = CommentWriteRequest(
+            content = "댓글 추가",
+            userId = 0,
+            originalCommentId = null
+        )
+        val request = jacksonObjectMapper().writeValueAsString(articleWriteRequest)
+
+        mockMvc.perform(
+            post(url)
+                .content(request)
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.code").value(ErrorCode.USER_NOT_FOUND.code))
+    }
+
+    @Test
+    @DisplayName("실패_댓글이 너무 길 때_댓글 작성에 실패한다")
+    fun writeCommentFailTooLongComment() {
+        val article = articleRepository.findAll()[0]
+        val user = userRepository.findAll()[0]
+        val url = "/community/article/${article.id}/comments"
+        val articleWriteRequest = CommentWriteRequest(
+            content = """
+                512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복
+                512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복
+                512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복
+                512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복
+                512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복
+                512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복
+            """.trimIndent(),
+            userId = user.id,
+            originalCommentId = null
+        )
+        val request = jacksonObjectMapper().writeValueAsString(articleWriteRequest)
+
+        mockMvc.perform(
+            post(url)
+                .content(request)
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.code").value(ErrorCode.COMMENT_TOO_LONG.code))
+    }
+
+    @Test
+    @DisplayName("실패_원댓글이 없을 때_댓글 작성에 실패한다")
+    fun writeCommentFailNoOriginalArticle() {
+        val article = articleRepository.findAll()[0]
+        val user = userRepository.findAll()[0]
+        val url = "/community/article/${article.id}/comments"
+        val articleWriteRequest = CommentWriteRequest(
+            content = "대충 댓글 내용",
+            userId = user.id,
+            originalCommentId = 0
+        )
+        val request = jacksonObjectMapper().writeValueAsString(articleWriteRequest)
+
+        mockMvc.perform(
+            post(url)
+                .content(request)
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.code").value(ErrorCode.COMMENT_NOT_FOUND.code))
+    }
+
+    @Test
+    @DisplayName("실패_원댓글이 다른 게시글일 때_댓글 작성에 실패한다")
+    fun writeCommentFailDifferentArticle() {
+        val article = articleRepository.findAll()[0]
+        val originalComment = commentRepository.findAll().filter {
+            it.article.id != article.id
+        }[0]
+        val user = userRepository.findAll()[0]
+        val url = "/community/article/${article.id}/comments"
+        val articleWriteRequest = CommentWriteRequest(
+            content = "대충 댓글 내용",
+            userId = user.id,
+            originalCommentId = originalComment.id
+        )
+        val request = jacksonObjectMapper().writeValueAsString(articleWriteRequest)
+
+        mockMvc.perform(
+            post(url)
+                .content(request)
+                .contentType(MediaType.APPLICATION_JSON)
+        ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.code").value(ErrorCode.DIFFERENT_ARTICLE.code))
+    }
+
+    @Test
+    @DisplayName("성공_올바른 정보를 넘겨줄 때_댓글들이 조회된다")
+    fun getComment() {
+        val articleId = commentRepository.findAll()[0].article.id
+        val url = "/community/article/${articleId}/comments"
+
+        mockMvc.perform(get(url))
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    @DisplayName("실패_게시글을 못 찾을 때_댓글 조회에 실패한다")
+    fun getCommentFailNoArticle() {
+        val url = "/community/article/0/comments"
+
+        mockMvc.perform(get(url))
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.code").value(ErrorCode.ARTICLE_NOT_FOUND.code))
     }
 }

--- a/src/test/kotlin/com/example/daitssuapi/domain/main/service/ArticleServiceTest.kt
+++ b/src/test/kotlin/com/example/daitssuapi/domain/main/service/ArticleServiceTest.kt
@@ -1,21 +1,28 @@
 package com.example.daitssuapi.domain.main.service
 
+import com.example.daitssuapi.common.exception.DefaultException
 import com.example.daitssuapi.domain.main.dto.request.ArticleWriteRequest
+import com.example.daitssuapi.domain.main.dto.request.CommentWriteRequest
 import com.example.daitssuapi.domain.main.dto.response.ArticleResponse
 import com.example.daitssuapi.domain.main.enums.Topic
 import com.example.daitssuapi.domain.main.model.entity.Article
 import com.example.daitssuapi.domain.main.model.repository.ArticleRepository
+import com.example.daitssuapi.domain.main.model.repository.CommentRepository
 import com.example.daitssuapi.domain.main.model.repository.UserRepository
 import com.example.daitssuapi.utils.IntegrationTest
+import org.assertj.core.api.Assertions.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.junit.jupiter.api.assertThrows
 
 @IntegrationTest
 class ArticleServiceTest(
     private val articleService: ArticleService,
     private val userRepository: UserRepository,
-    private val articleRepository: ArticleRepository
+    private val articleRepository: ArticleRepository,
+    private val commentRepository: CommentRepository
 ) {
     @Test
     @DisplayName("article 생성 테스트")
@@ -61,5 +68,121 @@ class ArticleServiceTest(
         assertEquals(articleResponse.title, savedArticle.title)
         assertEquals(articleResponse.content, savedArticle.content)
         assertEquals(articleResponse.writerNickName, savedArticle.writer.nickname)
+    }
+
+    @Test
+    @DisplayName("성공_올바른 정보를 넘겨줄 때_댓글이 작성된다")
+    fun writeComment() {
+        val article = articleRepository.findAll()[0]
+        val user = userRepository.findAll()[0]
+        val request = CommentWriteRequest(
+            content = "댓글 추가",
+            userId = user.id,
+            originalCommentId = null
+        )
+
+        val response = articleService.writeComment(articleId = article.id, request = request)
+
+        assertAll(
+            { assertThat(response.userId).isEqualTo(user.id) },
+            { assertThat(response.content).isEqualTo(request.content) },
+            { assertThat(response.originalCommentId).isEqualTo(request.originalCommentId) }
+        )
+    }
+
+    @Test
+    @DisplayName("실패_게시글이 없을 때_댓글 작성에 실패한다")
+    fun writeCommentFailNoArticle() {
+        val user = userRepository.findAll()[0]
+        val request = CommentWriteRequest(
+            content = "댓글 추가",
+            userId = user.id,
+            originalCommentId = null
+        )
+
+        assertThrows<DefaultException> { articleService.writeComment(articleId = 0, request = request) }
+    }
+
+    @Test
+    @DisplayName("실패_유저가 없을 때_댓글 작성에 실패한다")
+    fun writeCommentFailNoUser() {
+        val article = articleRepository.findAll()[0]
+        val request = CommentWriteRequest(
+            content = "댓글 추가",
+            userId = 0,
+            originalCommentId = null
+        )
+
+        assertThrows<DefaultException> { articleService.writeComment(articleId = article.id, request = request) }
+    }
+
+    @Test
+    @DisplayName("실패_댓글이 너무 길 때_댓글 작성에 실패한다")
+    fun writeCommentFailTooLongComment() {
+        val article = articleRepository.findAll()[0]
+        val user = userRepository.findAll()[0]
+        val request = CommentWriteRequest(
+            content = """
+                512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복
+                512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복
+                512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복
+                512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복
+                512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복
+                512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복512Byte 넘기기 위해 대충 반복
+            """.trimIndent(),
+            userId = user.id,
+            originalCommentId = null
+        )
+
+        assertThrows<DefaultException> { articleService.writeComment(articleId = article.id, request = request) }
+    }
+
+    @Test
+    @DisplayName("실패_원댓글이 없을 때_댓글 작성에 실패한다")
+    fun writeCommentFailNoOriginalArticle() {
+        val article = articleRepository.findAll()[0]
+        val user = userRepository.findAll()[0]
+        val request = CommentWriteRequest(
+            content = "대충 댓글 내용",
+            userId = user.id,
+            originalCommentId = 0
+        )
+
+        assertThrows<DefaultException> { articleService.writeComment(articleId = article.id, request = request) }
+    }
+
+    @Test
+    @DisplayName("실패_원댓글이 다른 게시글일 때_댓글 작성에 실패한다")
+    fun writeCommentFailDifferentArticle() {
+        val article = articleRepository.findAll()[0]
+        val originalComment = commentRepository.findAll().filter {
+            it.article.id != article.id
+        }[0]
+        val user = userRepository.findAll()[0]
+        val request = CommentWriteRequest(
+            content = "대충 댓글 내용",
+            userId = user.id,
+            originalCommentId = originalComment.id
+        )
+
+        assertThrows<DefaultException> { articleService.writeComment(articleId = article.id, request = request) }
+    }
+
+    @Test
+    @DisplayName("성공_올바른 정보를 넘겨줄 때_댓글들이 조회된다")
+    fun getComment() {
+        val comment = commentRepository.findAll()[0]
+
+        val response = articleService.getComments(articleId = comment.article.id)
+
+        assertAll(
+            { assertThat(response.size).isNotEqualTo(0) }
+        )
+    }
+
+    @Test
+    @DisplayName("실패_게시글을 못 찾을 때_댓글 조회에 실패한다")
+    fun getCommentFailNoArticle() {
+        assertThrows<DefaultException> { articleService.getComments(articleId = 0) }
     }
 }

--- a/src/test/resources/h2-data.sql
+++ b/src/test/resources/h2-data.sql
@@ -1,5 +1,6 @@
 DELETE FROM course.user_course_relation;
 DELETE FROM course.course;
+DELETE FROM main.article;
 DELETE FROM main.users;
 DELETE FROM main.department;
 DELETE FROM notice.notice;
@@ -15,6 +16,16 @@ INSERT INTO main.users(id, student_id, name, nickname, department_id, term) VALU
     (2, 2002, 'Bravo', 'B', 2, 2),
     (3, 3003, 'Charlie', null, 2, 2),
     (4, 4004, 'Delta', 'D', 3, 3);
+
+INSERT INTO main.article(id, topic, title, content, user_id, image_url, created_at, updated_at) VALUES
+    (1, 'CHAT', '대충 제목1', '대충 내용1', 2, null, '2023-09-16 10:00:00.000', '2023-09-16 10:00:00.000'),
+    (2, 'QUESTION', '대충 제목2', '대충 내용1', 4, null, '2023-09-16 10:00:00.000', '2023-09-16 10:00:00.000'),
+    (3, 'INFORMATION', '대충 제목3', '대충 내용1', 4, null, '2023-09-16 10:00:00.000', '2023-09-16 10:00:00.000');
+
+INSERT INTO main.comment(id, user_id, article_id, content, original_id, created_at, updated_at) VALUES
+    (1, 1, 1, '대충 댓글 쓴거1', null, '2023-09-16 10:00:00.000', '2023-09-16 10:00:00.000'),
+    (2, 3, 1, '대충 대댓글 쓴거1', 1, '2023-09-16 10:00:00.000', '2023-09-16 10:00:00.000'),
+    (3, 1, 3, '대충 댓글 쓴거2', null, '2023-09-16 10:00:00.000', '2023-09-16 10:00:00.000');
 
 INSERT INTO course.course (id, name, term, created_at, updated_at) VALUES
     (1, 'eat paper', 15, '2023-07-27 10:00:00.000', '2023-07-27 10:00:00.000'),


### PR DESCRIPTION
## Issue

- Resolves #22 

## Description

- BaseEntity 수정
  - H2는 `SEQUENCE`라서 `AUTO`로 변경
- 댓글 작성 기능 추가
  - 대댓글 기능 예상하고 우선 작업 완료
  - 대댓글의 대댓글도 가능한 상황 -> 추후 대댓글 기능 도입할 때 다시 검토
- 댓글 조회 기능 추가

## Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  적절한 라벨 설정
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x]  `main` 브랜치의 최신 상태를 반영하고 있는지 확인