### PR TITLE
[마이페이지] 나의 과목별 공지 조회

### DIFF
--- a/src/main/kotlin/com/example/daitssuapi/domain/course/controller/CourseController.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/course/controller/CourseController.kt
@@ -5,6 +5,8 @@ import com.example.daitssuapi.common.security.component.ArgumentResolver
 import com.example.daitssuapi.domain.course.dto.request.AssignmentCreateRequest
 import com.example.daitssuapi.domain.course.dto.request.AssignmentUpdateRequest
 import com.example.daitssuapi.domain.course.dto.request.CalendarRequest
+import com.example.daitssuapi.domain.course.dto.request.CourseNoticeCreateRequest
+import com.example.daitssuapi.domain.course.dto.request.CourseNoticeUpdateRequest
 import com.example.daitssuapi.domain.course.dto.request.CourseRequest
 import com.example.daitssuapi.domain.course.dto.request.VideoRequest
 import com.example.daitssuapi.domain.course.dto.response.*
@@ -155,4 +157,55 @@ class CourseController(
     fun getTodayCalendar(): Response<TodayCalendarResponse> =
         Response(data = courseService.getTodayDueAtCalendars())
 
+    @Operation(
+        summary = "공지 리스트 조회",
+        responses = [
+            ApiResponse(responseCode = "200", description = "OK")
+        ]
+    )
+    @GetMapping("{courseId}/notices")
+    fun getNotices(
+        @PathVariable courseId: Long
+    ): Response<List<CourseNoticeResponse>> =
+        Response(data = courseService.getNotices(courseId = courseId))
+
+    @Operation(
+        summary = "공지 조회",
+        responses = [
+            ApiResponse(responseCode = "200", description = "OK")
+        ]
+    )
+    @GetMapping("{courseId}/notices/{noticeId}")
+    fun viewNotice(
+        @PathVariable courseId: Long,
+        @PathVariable noticeId: Long
+    ): Response<CourseNoticeResponse> =
+        Response(data = courseService.getNotice(courseId = courseId, noticeId = noticeId))
+
+    @Operation(
+        summary = "공지 등록",
+        responses = [
+            ApiResponse(responseCode = "200", description = "OK")
+        ]
+    )
+    @PostMapping("{courseId}/notices")
+    fun createNotice(
+        @PathVariable courseId: Long,
+        @RequestBody request: CourseNoticeCreateRequest
+    ): Response<CourseNoticeResponse> =
+        Response(data = courseService.createNotice(request = request))
+
+    @Operation(
+        summary = "공지 수정",
+        responses = [
+            ApiResponse(responseCode = "200", description = "OK")
+        ]
+    )
+    @PutMapping("{courseId}/notices/{noticeId}")
+    fun updateNotice(
+        @PathVariable courseId: Long,
+        @PathVariable noticeId: Long,
+        @RequestBody request: CourseNoticeUpdateRequest
+    ): Response<CourseNoticeResponse> =
+        Response(data = courseService.updateNotice(noticeId = noticeId, request = request))
 }

--- a/src/main/kotlin/com/example/daitssuapi/domain/course/dto/request/CourseNoticeCreateRequest.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/course/dto/request/CourseNoticeCreateRequest.kt
@@ -1,0 +1,20 @@
+package com.example.daitssuapi.domain.course.dto.request
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(name = "공지 등록 API Request Body")
+data class CourseNoticeCreateRequest(
+    @Schema(description = "강의 id")
+    val courseId: Long,
+    @Schema(description = "공지 이름")
+    val name: String,
+    @Schema(description = "공지 등록일시")
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    val registeredAt: LocalDateTime,
+    @Schema(description = "공지 내용")
+    val content: String,
+    @Schema(description = "공지 첨부 파일")
+    val fileUrl: List<String>? = null
+)

--- a/src/main/kotlin/com/example/daitssuapi/domain/course/dto/request/CourseNoticeUpdateRequest.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/course/dto/request/CourseNoticeUpdateRequest.kt
@@ -1,0 +1,11 @@
+package com.example.daitssuapi.domain.course.dto.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(name = "공지 수정 API Request Body")
+data class CourseNoticeUpdateRequest(
+    @Schema(description = "공지 내용")
+    val content: String? = null,
+    @Schema(description = "공지 첨부 파일")
+    val fileUrl: List<String>? = null
+)

--- a/src/main/kotlin/com/example/daitssuapi/domain/course/dto/response/CourseNoticeResponse.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/course/dto/response/CourseNoticeResponse.kt
@@ -1,0 +1,28 @@
+package com.example.daitssuapi.domain.course.dto.response
+
+import com.example.daitssuapi.domain.course.model.entity.CourseNotice
+import java.time.LocalDateTime
+
+data class CourseNoticeResponse(
+    val id: Long,
+    val courseId: Long,
+    val isActive: Boolean,
+    val views: Int,
+    val content: String,
+    val fileUrl: List<String>,
+    val registeredAt: LocalDateTime
+) {
+    companion object {
+        fun of(notice: CourseNotice) = with(notice) {
+            CourseNoticeResponse(
+                id = id,
+                courseId = course.id,
+                isActive = isActive,
+                views = views,
+                content = content,
+                fileUrl = fileUrl,
+                registeredAt = registeredAt
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/example/daitssuapi/domain/course/model/entity/Course.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/course/model/entity/Course.kt
@@ -16,7 +16,10 @@ class Course(
     val videos: MutableList<Video> = mutableListOf(),
 
     @OneToMany(mappedBy = "course")
-    val assignments: MutableList<Assignment> = mutableListOf()
+    val assignments: MutableList<Assignment> = mutableListOf(),
+
+    @OneToMany(mappedBy = "course")
+    val courseNotices: MutableList<CourseNotice> = mutableListOf()
 ) : BaseEntity() {
     fun addVideo(video: Video) {
         videos.add(video)

--- a/src/main/kotlin/com/example/daitssuapi/domain/course/model/entity/CourseNotice.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/course/model/entity/CourseNotice.kt
@@ -1,0 +1,46 @@
+package com.example.daitssuapi.domain.course.model.entity
+
+import com.example.daitssuapi.common.audit.BaseEntity
+import com.example.daitssuapi.common.converter.JsonParsingConverter
+import jakarta.persistence.Convert
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import java.time.LocalDateTime
+
+@Entity
+class CourseNotice(
+    val isActive: Boolean = true,
+
+    val name: String,
+
+    val registeredAt: LocalDateTime,
+
+    var views: Int = 0,
+
+    var content: String,
+
+    @Convert(converter = JsonParsingConverter::class)
+    var fileUrl: List<String> = emptyList(),
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "course_id")
+    var course: Course,
+) : BaseEntity() {
+    fun viewNotice() {
+        this.views += 1
+    }
+
+    fun update(
+        content: String? = null,
+        fileUrl: List<String>? = null
+    ) {
+        content?.also {
+            this.content = content
+        }
+        fileUrl?.also {
+            this.fileUrl = fileUrl
+        }
+    }
+}

--- a/src/main/kotlin/com/example/daitssuapi/domain/course/model/repository/CourseNoticeRepository.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/course/model/repository/CourseNoticeRepository.kt
@@ -1,0 +1,10 @@
+package com.example.daitssuapi.domain.course.model.repository
+
+import com.example.daitssuapi.domain.course.model.entity.CourseNotice
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface CourseNoticeRepository : JpaRepository<CourseNotice, Long> {
+    fun findByCourseId(courseId: Long): List<CourseNotice>
+}

--- a/src/main/kotlin/com/example/daitssuapi/domain/myPage/controller/MyPageController.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/myPage/controller/MyPageController.kt
@@ -3,6 +3,7 @@ package com.example.daitssuapi.domain.myPage.controller
 import com.example.daitssuapi.common.dto.Response
 import com.example.daitssuapi.common.security.component.ArgumentResolver
 import com.example.daitssuapi.domain.article.dto.response.CommentResponse
+import com.example.daitssuapi.domain.main.dto.response.ServiceNoticeResponse
 import com.example.daitssuapi.domain.myPage.dto.request.CommentDeleteRequest
 import com.example.daitssuapi.domain.myPage.dto.response.MyArticleResponse
 import com.example.daitssuapi.domain.myPage.dto.response.MyScrapResponse
@@ -71,4 +72,16 @@ class MyPageController(
         
         return Response(data = myPageService.getMyScrap(userId = userId))
     }
+
+    @Operation(
+        summary = "서비스 공지사항 전체 조회",
+        responses = [
+            ApiResponse(responseCode = "200", description = "OK")
+        ]
+    )
+    @GetMapping("/service-notice")
+    fun getServiceNotice(): Response<List<ServiceNoticeResponse>> =
+        Response(data = myPageService.getServiceNotice())
+
+
 }

--- a/src/main/kotlin/com/example/daitssuapi/domain/myPage/controller/MyPageController.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/myPage/controller/MyPageController.kt
@@ -6,12 +6,14 @@ import com.example.daitssuapi.domain.article.dto.response.CommentResponse
 import com.example.daitssuapi.domain.myPage.dto.request.CommentDeleteRequest
 import com.example.daitssuapi.domain.myPage.dto.response.MyArticleResponse
 import com.example.daitssuapi.domain.myPage.dto.response.MyAssignmentResponse
+import com.example.daitssuapi.domain.myPage.dto.response.MyCourseNoticeResponse
 import com.example.daitssuapi.domain.myPage.dto.response.MyScrapResponse
 import com.example.daitssuapi.domain.myPage.service.MyPageService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -87,5 +89,20 @@ class MyPageController(
         val userId = argumentResolver.resolveUserId()
 
         return Response(data = myPageService.getAssignments(userId = userId, courseId = courseId))
+    }
+
+    @Operation(
+        summary = "나의 강의의 공지 리스트 조회",
+        responses = [
+            ApiResponse(responseCode = "200", description = "OK")
+        ]
+    )
+    @GetMapping("/course/{courseId}/notices")
+    fun getCourseNotices(
+        @PathVariable courseId: Long
+    ): Response<List<MyCourseNoticeResponse>> {
+        val userId = argumentResolver.resolveUserId()
+
+        return Response(data = myPageService.getCourseNotices(userId = userId, courseId = courseId))
     }
 }

--- a/src/main/kotlin/com/example/daitssuapi/domain/myPage/dto/response/MyCourseNoticeResponse.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/myPage/dto/response/MyCourseNoticeResponse.kt
@@ -1,0 +1,14 @@
+package com.example.daitssuapi.domain.myPage.dto.response
+
+import java.time.LocalDateTime
+
+data class MyCourseNoticeResponse(
+    val id: Long,
+    val course: MyCourseSimpleResponse,
+    val name: String,
+    val isActive: Boolean,
+    val registeredAt: LocalDateTime? = null,
+    val views: Int,
+    val content: String,
+    val fileUrl: List<String>
+)

--- a/src/main/kotlin/com/example/daitssuapi/domain/myPage/dto/response/ServiceNoticeResponse.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/myPage/dto/response/ServiceNoticeResponse.kt
@@ -1,0 +1,11 @@
+package com.example.daitssuapi.domain.main.dto.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(name = "서비스 공지사항 조회 Response")
+data class ServiceNoticeResponse (
+    val title : String,
+    val content : String,
+    val createdAt : LocalDateTime
+)

--- a/src/main/kotlin/com/example/daitssuapi/domain/myPage/model/entity/ServiceNotice.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/myPage/model/entity/ServiceNotice.kt
@@ -1,0 +1,16 @@
+package com.example.daitssuapi.domain.main.model.entity
+
+import com.example.daitssuapi.common.audit.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+
+@Entity
+class ServiceNotice(
+
+    @Column(length = 1024)
+    val title : String,
+
+    @Column(length = 2048)
+    val content : String,
+
+) : BaseEntity()

--- a/src/main/kotlin/com/example/daitssuapi/domain/myPage/model/repository/ServiceNoticeRepository.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/myPage/model/repository/ServiceNoticeRepository.kt
@@ -1,0 +1,9 @@
+
+package com.example.daitssuapi.domain.main.model.repository
+
+import com.example.daitssuapi.domain.main.model.entity.ServiceNotice
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface ServiceNoticeRepository : JpaRepository<ServiceNotice, Long> {
+
+}

--- a/src/main/kotlin/com/example/daitssuapi/domain/myPage/service/MyPageService.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/myPage/service/MyPageService.kt
@@ -10,6 +10,7 @@ import com.example.daitssuapi.domain.course.model.repository.CourseRepository
 import com.example.daitssuapi.domain.course.model.repository.UserCourseRelationRepository
 import com.example.daitssuapi.domain.myPage.dto.response.MyArticleResponse
 import com.example.daitssuapi.domain.myPage.dto.response.MyAssignmentResponse
+import com.example.daitssuapi.domain.myPage.dto.response.MyCourseNoticeResponse
 import com.example.daitssuapi.domain.myPage.dto.response.MyCourseSimpleResponse
 import com.example.daitssuapi.domain.myPage.dto.response.MyScrapResponse
 import com.example.daitssuapi.domain.user.model.repository.UserRepository
@@ -101,6 +102,34 @@ class MyPageService(
                     comments = assignment.comments
                 )
             }
+        }
+    }
+
+    fun getCourseNotices(userId: Long, courseId: Long): List<MyCourseNoticeResponse> {
+        userRepository.findByIdOrNull(userId)
+            ?: throw DefaultException(errorCode = ErrorCode.USER_NOT_FOUND)
+
+        val course = courseRepository.findByIdOrNull(courseId)
+            ?: throw DefaultException(errorCode = ErrorCode.COURSE_NOT_FOUND)
+
+        val courseResponse = MyCourseSimpleResponse(
+            id = course.id,
+            name = course.name,
+            term = course.term,
+            courseCode = course.courseCode
+        )
+
+        return course.courseNotices.map { courseNotice ->
+            MyCourseNoticeResponse(
+                id = courseNotice.id,
+                course = courseResponse,
+                name = courseNotice.name,
+                isActive = courseNotice.isActive,
+                registeredAt = courseNotice.registeredAt,
+                views = courseNotice.views,
+                content = courseNotice.content,
+                fileUrl = courseNotice.fileUrl
+            )
         }
     }
 }

--- a/src/main/kotlin/com/example/daitssuapi/domain/myPage/service/MyPageService.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/myPage/service/MyPageService.kt
@@ -6,6 +6,8 @@ import com.example.daitssuapi.domain.article.dto.response.CommentResponse
 import com.example.daitssuapi.domain.article.model.repository.ArticleRepository
 import com.example.daitssuapi.domain.article.model.repository.CommentRepository
 import com.example.daitssuapi.domain.article.model.repository.ScrapRepository
+import com.example.daitssuapi.domain.main.dto.response.ServiceNoticeResponse
+import com.example.daitssuapi.domain.main.model.repository.ServiceNoticeRepository
 import com.example.daitssuapi.domain.myPage.dto.response.MyArticleResponse
 import com.example.daitssuapi.domain.myPage.dto.response.MyScrapResponse
 import com.example.daitssuapi.domain.user.model.repository.UserRepository
@@ -19,6 +21,7 @@ class MyPageService(
     private val articleRepository: ArticleRepository,
     private val commentRepository: CommentRepository,
     private val scrapRepository: ScrapRepository,
+    private val serviceNoticeRepository: ServiceNoticeRepository,
 ) {
     fun getComments(userId: Long): List<CommentResponse> {
         userRepository.findByIdOrNull(id = userId) ?: throw DefaultException(errorCode = ErrorCode.USER_NOT_FOUND)
@@ -63,6 +66,15 @@ class MyPageService(
                 commentSize = it.article.comments.count { comment -> !comment.isDeleted }
             )
         }
-        
+    }
+
+    fun getServiceNotice():List<ServiceNoticeResponse>{
+        return serviceNoticeRepository.findAll().map { serviceNotice ->
+            ServiceNoticeResponse(
+                title = serviceNotice.title,
+                content = serviceNotice.content,
+                createdAt = serviceNotice.createdAt
+            )
+        }
     }
 }

--- a/src/test/kotlin/com/example/daitssuapi/domain/myPage/controller/MyPageControllerTest.kt
+++ b/src/test/kotlin/com/example/daitssuapi/domain/myPage/controller/MyPageControllerTest.kt
@@ -157,6 +157,16 @@ class MyPageControllerTest(
     }
 
     @Test
+    @DisplayName("실패_올바르지 않은 userId 넘겨주면_과제 조회에 실패한다")
+    fun failGetAssignments() {
+        val accessToken = tokenProvider.createAccessToken(id = 0L).token
+
+        mockMvc.perform(get("$baseUrl/assignments")
+            .header(HttpHeaders.AUTHORIZATION, "Bearer $accessToken")
+        ).andExpect(status().isBadRequest)
+    }
+
+    @Test
     @DisplayName("실패_올바르지 않은 courseId를 넘겨주면_과제 조회에 실패한다")
     fun failGetAssignmentsWithCourseId() {
         val accessToken = tokenProvider.createAccessToken(id = 1L).token
@@ -169,12 +179,39 @@ class MyPageControllerTest(
     }
 
     @Test
-    @DisplayName("실패_올바르지 않은 userId 넘겨주면_과제 조회에 실패한다")
-    fun failGetAssignments() {
-        val accessToken = tokenProvider.createAccessToken(id = 0L).token
+    @DisplayName("성공_올바른 userId와 courseId를 넘겨주면_과제를 조회한다")
+    fun successGetCourseNotices() {
+        val accessToken = tokenProvider.createAccessToken(id = 1L).token
+        val courseId = 1L
 
-        mockMvc.perform(get("$baseUrl/assignments")
+        mockMvc.perform(get("$baseUrl/course/$courseId/notices")
             .header(HttpHeaders.AUTHORIZATION, "Bearer $accessToken")
+            .param("courseId", courseId.toString())
+        ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.data").isNotEmpty)
+    }
+
+    @Test
+    @DisplayName("실패_올바르지 않은 userId 넘겨주면_과제 조회에 실패한다")
+    fun failGetCourseNotices() {
+        val accessToken = tokenProvider.createAccessToken(id = 0L).token
+        val courseId = 1L
+
+        mockMvc.perform(get("$baseUrl/course/$courseId/notices")
+            .header(HttpHeaders.AUTHORIZATION, "Bearer $accessToken")
+            .param("courseId", courseId.toString())
+        ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    @DisplayName("실패_올바르지 않은 courseId를 넘겨주면_과제 조회에 실패한다")
+    fun failGetCourseNoticesWithCourseId() {
+        val accessToken = tokenProvider.createAccessToken(id = 1L).token
+        val wrongCourseId = 0L
+
+        mockMvc.perform(get("$baseUrl/course/$wrongCourseId/notices")
+            .header(HttpHeaders.AUTHORIZATION, "Bearer $accessToken")
+            .param("courseId", wrongCourseId.toString())
         ).andExpect(status().isBadRequest)
     }
 }

--- a/src/test/kotlin/com/example/daitssuapi/domain/myPage/controller/MyPageControllerTest.kt
+++ b/src/test/kotlin/com/example/daitssuapi/domain/myPage/controller/MyPageControllerTest.kt
@@ -131,4 +131,16 @@ class MyPageControllerTest(
         ).andExpect(status().isOk)
             .andExpect(jsonPath("$.data").isEmpty)
     }
+
+    @Test
+    @DisplayName("서비스 공지사항 전제 조회")
+    fun get_service_notice() {
+
+        mockMvc.perform(get("$baseUrl/service-notice"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data").isNotEmpty)
+            .andReturn()
+    }
+
+
 }

--- a/src/test/kotlin/com/example/daitssuapi/domain/mypage/service/MypageServiceTest.kt
+++ b/src/test/kotlin/com/example/daitssuapi/domain/mypage/service/MypageServiceTest.kt
@@ -151,6 +151,14 @@ class MyPageServiceTest(
     }
 
     @Test
+    @DisplayName("실패_올바르지 않은 userId를 넘겨주면_과제 조회에 실패한다")
+    fun failGetAssignments() {
+        val userId = 0L
+
+        assertThrows<DefaultException> { myPageService.getAssignments(userId = userId) }
+    }
+
+    @Test
     @DisplayName("실패_올바르지 않은 courseId를 넘겨주면_과제 조회에 실패한다")
     fun failGetAssignmentsWithCourseId() {
         val userId = 1L
@@ -160,10 +168,31 @@ class MyPageServiceTest(
     }
 
     @Test
-    @DisplayName("실패_올바르지 않은 userId 넘겨주면_과제 조회에 실패한다")
-    fun failGetAssignments() {
-        val userId = 0L
+    @DisplayName("성공_올바른 userId와 courseId를 넘겨주면_해당 강의의 공지 리스트를 조회한다")
+    fun successGetCourseNotices() {
+        val userId = 1L
+        val courseId = 1L
 
-        assertThrows<DefaultException> { myPageService.getAssignments(userId = userId) }
+        val assignments = myPageService.getCourseNotices(userId = userId, courseId = courseId)
+
+        assertThat(assignments.isNotEmpty())
+    }
+
+    @Test
+    @DisplayName("실패_올바르지 않은 userId를 넘겨주면_공지 조회에 실패한다")
+    fun failGetCourseNotices() {
+        val userId = 0L
+        val courseId = 1L
+
+        assertThrows<DefaultException> { myPageService.getCourseNotices(userId = userId, courseId = courseId) }
+    }
+
+    @Test
+    @DisplayName("실패_올바르지 않은 courseId를 넘겨주면_과제 조회에 실패한다")
+    fun failGetCourseNoticesWithCourseId() {
+        val userId = 1L
+        val courseId = 0L
+
+        assertThrows<DefaultException> { myPageService.getCourseNotices(userId = userId, courseId = courseId) }
     }
 }

--- a/src/test/resources/h2-data.sql
+++ b/src/test/resources/h2-data.sql
@@ -10,6 +10,7 @@ DELETE FROM users;
 DELETE FROM department;
 DELETE FROM notice;
 DELETE FROM notice_fs;
+DELETE FROM service_notice;
 
 INSERT INTO department(id, name) VALUES
     (1, 'computer'),
@@ -90,3 +91,6 @@ INSERT INTO notice_fs(id, title, content, category,url, image_url, created_at, u
     (3,'공지사항3','3번 공지 내용입니다!!','CERTIFICATION','http://google.com', '{"url": []}', '1000-01-01 00:00:00','1000-01-01 00:00:00',0),
     (4,'공지사항4','4번 공지 내용입니다!!','EXPERIENTIAL_ACTIVITIES','http://google.com', '{"url": []}', '1000-01-01 00:00:00','1000-01-01 00:00:00',0),
     (5,'공지사항5','5번 공지 내용입니다!!','EXPERIENTIAL_ACTIVITIES','http://google.com', '{"url": []}', '1000-01-01 00:00:00','1000-01-01 00:00:00',0);
+
+INSERT INTO service_notice(id, title, content, created_at, updated_at ) VALUES
+    (1, '6/23 (금) 시스템 점검 및 업데이트 안내', '안녕하세요 다잇슈입니다. 더욱 쾌적하고 안정적인 서비스 지원을 위해 아래와 같이 점검이 진행됩니다.', '2023-12-06 06:44:07', '2023-12-06 06:44:07');

--- a/src/test/resources/h2-data.sql
+++ b/src/test/resources/h2-data.sql
@@ -10,6 +10,7 @@ DELETE FROM users;
 DELETE FROM department;
 DELETE FROM notice;
 DELETE FROM notice_fs;
+DELETE FROM course_notice;
 
 INSERT INTO department(id, name) VALUES
     (1, 'computer'),
@@ -87,3 +88,6 @@ INSERT INTO notice_fs(id, title, content, category,url, image_url, created_at, u
     (3,'공지사항3','3번 공지 내용입니다!!','CERTIFICATION','http://google.com', '{"url": []}', '1000-01-01 00:00:00','1000-01-01 00:00:00',0),
     (4,'공지사항4','4번 공지 내용입니다!!','EXPERIENTIAL_ACTIVITIES','http://google.com', '{"url": []}', '1000-01-01 00:00:00','1000-01-01 00:00:00',0),
     (5,'공지사항5','5번 공지 내용입니다!!','EXPERIENTIAL_ACTIVITIES','http://google.com', '{"url": []}', '1000-01-01 00:00:00','1000-01-01 00:00:00',0);
+
+INSERT INTO course_notice(id, course_id, is_active, name, registered_at, views, content, file_url) VALUES
+    (1, 1, true, '강의의 공지1', '2024-01-01 04:16:12', 3, '공지 상세 내용', '{"url": []}')


### PR DESCRIPTION
## Issue

- Resolves #78 

## Description

- 강의의 공지 Entity 및 Repository 추가
- 강의별 공지 등록, 수정, 조회 기능 추가
- 나의 강의별 공지 리스트 조회 기능 추가
  - 나의 강의별 상세 공지 -> 강의별 공지 조회 기능 이용
- Conflict 많이 날 것 같아서 #105 에서 branch 땀
  - 이거 먼저 merge || 이거 base branch 바꾸고 merge해야함

## Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  적절한 라벨 설정
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [ ]  `main` 브랜치의 최신 상태를 반영하고 있는지 확인
