### PR TITLE
fix : Comment 조회 시 닉네임도 전달

### DIFF
--- a/src/main/kotlin/com/example/daitssuapi/domain/article/dto/response/CommentResponse.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/article/dto/response/CommentResponse.kt
@@ -6,6 +6,7 @@ import java.time.LocalDateTime
 data class CommentResponse(
     val commentId: Long,
     val userId: Long,
+    val nickname: String? = null,
     val content: String,
     val originalCommentId: Long? = null,
     val createdAt: LocalDateTime,
@@ -16,6 +17,7 @@ data class CommentResponse(
             CommentResponse(
                 commentId = id,
                 userId = writer.id,
+                nickname = writer.nickname,
                 content = content,
                 originalCommentId = originalId,
                 createdAt = createdAt,

--- a/src/main/kotlin/com/example/daitssuapi/domain/article/service/ArticleService.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/article/service/ArticleService.kt
@@ -221,14 +221,7 @@ class ArticleService(
             )
         )
 
-        return CommentResponse(
-            commentId = comment.id,
-            userId = comment.writer.id,
-            content = comment.content,
-            originalCommentId = comment.originalId,
-            createdAt = comment.createdAt,
-            updatedAt = comment.updatedAt
-        )
+        return CommentResponse.of(comment = comment)
     }
 
     @Transactional
@@ -291,16 +284,7 @@ class ArticleService(
         articleRepository.findByIdOrNull(articleId)
             ?: throw DefaultException(errorCode = ErrorCode.ARTICLE_NOT_FOUND)
 
-        return commentRepository.findByArticleId(articleId = articleId).map {
-            CommentResponse(
-                commentId = it.id,
-                userId = it.writer.id,
-                content = it.content,
-                originalCommentId = it.originalId,
-                createdAt = it.createdAt,
-                updatedAt = it.updatedAt
-            )
-        }
+        return commentRepository.findByArticleId(articleId = articleId).map(CommentResponse::of)
     }
 
     @Transactional

--- a/src/main/kotlin/com/example/daitssuapi/domain/notice/service/FunSystemService.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/notice/service/FunSystemService.kt
@@ -95,14 +95,7 @@ class FunSystemService(
             originalId = request.originalCommentId
         ))
 
-        return CommentResponse(
-            commentId = comment.id,
-            userId = comment.writer.id,
-            content = comment.content,
-            originalCommentId = comment.originalId,
-            createdAt = comment.createdAt,
-            updatedAt = comment.updatedAt
-        )
+        return CommentResponse.of(comment = comment)
     }
 
     private fun validateComment(funSystem: FunSystem, content: String, originalCommentId: Long?) {
@@ -124,15 +117,6 @@ class FunSystemService(
         funSystemRepository.findByIdOrNull(funSystemId)
             ?: throw DefaultException(errorCode = ErrorCode.FUNSYSTEM_NOT_FOUND)
 
-        return commentRepository.findByFunSystemId(funSystemId = funSystemId).map {
-            CommentResponse(
-                commentId = it.id,
-                userId = it.writer.id,
-                content = it.content,
-                originalCommentId = it.originalId,
-                createdAt = it.createdAt,
-                updatedAt = it.updatedAt
-            )
-        }
+        return commentRepository.findByFunSystemId(funSystemId = funSystemId).map(CommentResponse::of)
     }
 }

--- a/src/main/kotlin/com/example/daitssuapi/domain/notice/service/NoticeService.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/notice/service/NoticeService.kt
@@ -96,14 +96,7 @@ class NoticeService(
             )
         )
 
-        return CommentResponse(
-            commentId = comment.id,
-            userId = comment.writer.id,
-            content = comment.content,
-            originalCommentId = comment.originalId,
-            createdAt = comment.createdAt,
-            updatedAt = comment.updatedAt
-        )
+        return CommentResponse.of(comment = comment)
     }
 
     private fun validateComment(notice: Notice, content: String, originalCommentId: Long?) {
@@ -125,16 +118,7 @@ class NoticeService(
         noticeRepository.findByIdOrNull(noticeId)
             ?: throw DefaultException(errorCode = ErrorCode.ARTICLE_NOT_FOUND)
 
-        return commentRepository.findByNoticeId(noticeId = noticeId).map {
-            CommentResponse(
-                commentId = it.id,
-                userId = it.writer.id,
-                content = it.content,
-                originalCommentId = it.originalId,
-                createdAt = it.createdAt,
-                updatedAt = it.updatedAt
-            )
-        }
+        return commentRepository.findByNoticeId(noticeId = noticeId).map(CommentResponse::of)
     }
 }
 

--- a/src/test/resources/h2-data.sql
+++ b/src/test/resources/h2-data.sql
@@ -91,6 +91,7 @@ INSERT INTO notice_fs(id, title, content, category,url, image_url, created_at, u
     (5,'공지사항5','5번 공지 내용입니다!!','EXPERIENTIAL_ACTIVITIES','http://google.com', '{"url": []}', '1000-01-01 00:00:00','1000-01-01 00:00:00',0);
 
 INSERT INTO course_notice(id, course_id, is_active, name, registered_at, views, content, file_url) VALUES
-    (1, 1, true, '강의의 공지1', '2024-01-01 04:16:12', 3, '공지 상세 내용', '{"url": []}')
+    (1, 1, true, '강의의 공지1', '2024-01-01 04:16:12', 3, '공지 상세 내용', '{"url": []}');
+
 INSERT INTO service_notice(id, title, content, created_at, updated_at ) VALUES
     (1, '6/23 (금) 시스템 점검 및 업데이트 안내', '안녕하세요 다잇슈입니다. 더욱 쾌적하고 안정적인 서비스 지원을 위해 아래와 같이 점검이 진행됩니다.', '2023-12-06 06:44:07', '2023-12-06 06:44:07');


### PR DESCRIPTION
## Description
- CommentResponse에 nickname 필드 추가
- 기존에 CommentResponse 직접 생성하던 것들 모두 `of` 생성자 이용하여 생성하도록 변경

## Check List

- [ ]  PR 제목을 커밋 규칙에 맞게 작성
- [ ]  PR에 해당되는 Issue를 연결 완료
- [ ]  적절한 라벨 설정
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x]  `main` 브랜치의 최신 상태를 반영하고 있는지 확인
