### PR TITLE
feat: article topic별로 가져오기 추가

### DIFF
--- a/src/main/kotlin/com/example/daitssuapi/domain/article/controller/ArticleController.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/article/controller/ArticleController.kt
@@ -8,6 +8,7 @@ import com.example.daitssuapi.domain.article.dto.request.CommentWriteRequest
 import com.example.daitssuapi.domain.article.dto.response.ArticleResponse
 import com.example.daitssuapi.domain.article.dto.response.CommentResponse
 import com.example.daitssuapi.domain.article.dto.response.PageArticlesResponse
+import com.example.daitssuapi.domain.article.enums.Topic
 import com.example.daitssuapi.domain.article.service.ArticleService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -68,6 +69,42 @@ sort: [\"createdAt\"]
         val articles = articleService.pageArticleList(
             inquiry = inquiry,
             pageable = pageable
+        )
+
+        return Response(
+            data = articles
+        )
+    }
+
+    @Operation(
+        summary = "게시글 토픽으로 조회",
+        responses = [
+            ApiResponse(
+                responseCode = "200",
+                description = "OK"
+            )
+        ]
+    )
+    @GetMapping("/topic")
+    fun pageArticleListWithTopic(
+        @Parameter(
+            description = """
+<b>[필수]</b> 조회할 Page, Page 당 개수, 정렬 기준입니다. <br />
+`page`는 zero-indexed 입니다. <br />
+<b>[기본 값]</b><br />
+page: 0 <br />
+size: 5 <br />
+sort: [\"createdAt\"]
+            """,
+        )
+        @PageableDefault(page = 0, size = 10, sort = ["createdAt"]) pageable: Pageable,
+        @RequestParam topic: Topic,
+        @RequestParam inquiry: String?,
+    ): Response<PageArticlesResponse> { // TODO : 유저의 nickname이 null이면 예외 파악이 매우 어려움
+        val articles = articleService.pageArticleListWithTopic(
+            inquiry = inquiry,
+            pageable = pageable,
+            topic = topic,
         )
 
         return Response(

--- a/src/main/kotlin/com/example/daitssuapi/domain/article/model/repository/ArticleRepository.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/article/model/repository/ArticleRepository.kt
@@ -21,6 +21,7 @@ interface ArticleRepository : JpaRepository<Article, Long> {
         pageable: Pageable,
     ):Page<Article>
 
+    // TODO : Query문 교체 필요
     @Query("SELECT a FROM Article a WHERE (a.topic = :topic) AND (a.title LIKE %:title% OR a.content LIKE %:content%)")
     fun findByTitleContainingOrContentContainingAndTopic(
         title: String,

--- a/src/main/kotlin/com/example/daitssuapi/domain/article/model/repository/ArticleRepository.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/article/model/repository/ArticleRepository.kt
@@ -1,10 +1,12 @@
 package com.example.daitssuapi.domain.article.model.repository
 
+import com.example.daitssuapi.domain.article.enums.Topic
 import com.example.daitssuapi.domain.article.model.entity.Article
 import com.example.daitssuapi.domain.user.model.entity.User
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
 import java.time.LocalDateTime
 
 interface ArticleRepository : JpaRepository<Article, Long> {
@@ -12,6 +14,19 @@ interface ArticleRepository : JpaRepository<Article, Long> {
         title: String,
         content: String,
         pageable: Pageable,
+    ): Page<Article>
+
+    fun findByTopic(
+        topic :Topic,
+        pageable: Pageable,
+    ):Page<Article>
+
+    @Query("SELECT a FROM Article a WHERE (a.topic = :topic) AND (a.title LIKE %:title% OR a.content LIKE %:content%)")
+    fun findByTitleContainingOrContentContainingAndTopic(
+        title: String,
+        content: String,
+        pageable: Pageable,
+        topic: Topic,
     ): Page<Article>
 
     fun findAllByCreatedAtIsGreaterThanEqual(

--- a/src/main/kotlin/com/example/daitssuapi/domain/article/service/ArticleService.kt
+++ b/src/main/kotlin/com/example/daitssuapi/domain/article/service/ArticleService.kt
@@ -10,6 +10,7 @@ import com.example.daitssuapi.domain.article.dto.request.CommentWriteRequest
 import com.example.daitssuapi.domain.article.dto.response.ArticleResponse
 import com.example.daitssuapi.domain.article.dto.response.CommentResponse
 import com.example.daitssuapi.domain.article.dto.response.PageArticlesResponse
+import com.example.daitssuapi.domain.article.enums.Topic
 import com.example.daitssuapi.domain.article.model.entity.Article
 import com.example.daitssuapi.domain.article.model.entity.ArticleLike
 import com.example.daitssuapi.domain.article.model.entity.Comment
@@ -69,6 +70,45 @@ class ArticleService(
                     title = inquiry,
                     content = inquiry,
                     pageable = pageable,
+                )
+
+        val articleResponses = articles.map {
+            ArticleResponse(
+                id = it.id,
+                topic = it.topic.value,
+                title = it.title,
+                content = it.content,
+                writerNickName = it.writer.nickname!!,
+                updatedAt = it.updatedAt,
+                imageUrls = it.imageUrl,
+                likes = it.likes.size,
+                comments = it.comments.size
+            )
+        }
+
+        return PageArticlesResponse(
+            articles = articleResponses.content,
+            totalPages = articleResponses.totalPages
+        )
+    }
+
+    // topic으로 article 가져오기
+    fun pageArticleListWithTopic(
+        pageable: Pageable,
+        inquiry: String?,
+        topic: Topic,
+    ): PageArticlesResponse {
+        val articles: Page<Article> =
+            if (inquiry == null)
+                articleRepository.findByTopic(
+                    pageable = pageable,
+                    topic = topic)
+            else
+                articleRepository.findByTitleContainingOrContentContainingAndTopic(
+                    title = inquiry,
+                    content = inquiry,
+                    pageable = pageable,
+                    topic = topic,
                 )
 
         val articleResponses = articles.map {


### PR DESCRIPTION
## Issue

- Resolves #60 

## Description

- 커뮤니티 topic별로 조회 다시 추가
- topic별로 조회 하면서 title or content 검색 
and랑 or 조건 jpa에서 동시에 적용이 안돼서 쿼리문으로 했는데 다른 방법 있으면 말씀해주세요..!

## Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  적절한 라벨 설정
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)
- [x]  `main` 브랜치의 최신 상태를 반영하고 있는지 확인

## Screenshot
